### PR TITLE
App모듈의 Theme 파일을 Resource모듈로 이동토록 함

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 
 dependencies {
 
+    implementation(project(":common:resource"))
     implementation(project(":easterdev:app"))
     implementation(project(":robin:app"))
     implementation(project(":whaleshark:app"))

--- a/app/src/main/java/dev/tuna/leechunbok/HomeScreen.kt
+++ b/app/src/main/java/dev/tuna/leechunbok/HomeScreen.kt
@@ -53,7 +53,7 @@ private fun MemberButtons(
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun MemberButtonsPreview() {
-    dev.tuna.leechunbok.resource.LeechunbokTheme {
+    LeechunbokTheme {
         MemberButtons(members = TunaMember.values())
     }
 }

--- a/app/src/main/java/dev/tuna/leechunbok/HomeScreen.kt
+++ b/app/src/main/java/dev/tuna/leechunbok/HomeScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import dev.tuna.leechunbok.ui.theme.LeechunbokTheme
+import dev.tuna.leechunbok.resource.LeechunbokTheme
 
 @Preview(showBackground = true)
 @Composable
@@ -53,7 +53,7 @@ private fun MemberButtons(
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun MemberButtonsPreview() {
-    LeechunbokTheme {
+    dev.tuna.leechunbok.resource.LeechunbokTheme {
         MemberButtons(members = TunaMember.values())
     }
 }

--- a/app/src/main/java/dev/tuna/leechunbok/MainActivity.kt
+++ b/app/src/main/java/dev/tuna/leechunbok/MainActivity.kt
@@ -9,7 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import dev.tuna.leechunbok.ui.theme.LeechunbokTheme
+import dev.tuna.leechunbok.resource.LeechunbokTheme
 
 class MainActivity : ComponentActivity() {
 
@@ -20,9 +20,12 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         splashScreen.setKeepOnScreenCondition { splashViewModel.splashLoadingState.value }
         setContent {
-            LeechunbokTheme {
+            dev.tuna.leechunbok.resource.LeechunbokTheme {
                 // A surface container using the 'background' color from the theme
-                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
                     HomeScreen()
                 }
             }

--- a/app/src/main/java/dev/tuna/leechunbok/MainActivity.kt
+++ b/app/src/main/java/dev/tuna/leechunbok/MainActivity.kt
@@ -20,7 +20,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         splashScreen.setKeepOnScreenCondition { splashViewModel.splashLoadingState.value }
         setContent {
-            dev.tuna.leechunbok.resource.LeechunbokTheme {
+            LeechunbokTheme {
                 // A surface container using the 'background' color from the theme
                 Surface(
                     modifier = Modifier.fillMaxSize(),

--- a/common/resource/build.gradle.kts
+++ b/common/resource/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
+apply(from = "${project.rootDir}/compose.gradle")
+
 android {
     namespace = "dev.tuna.leechunbok.resource"
     compileSdk = 33

--- a/common/resource/src/main/java/dev/tuna/leechunbok/resource/Color.kt
+++ b/common/resource/src/main/java/dev/tuna/leechunbok/resource/Color.kt
@@ -1,4 +1,4 @@
-package dev.tuna.leechunbok.ui.theme
+package dev.tuna.leechunbok.resource
 
 import androidx.compose.ui.graphics.Color
 

--- a/common/resource/src/main/java/dev/tuna/leechunbok/resource/Theme.kt
+++ b/common/resource/src/main/java/dev/tuna/leechunbok/resource/Theme.kt
@@ -1,4 +1,4 @@
-package dev.tuna.leechunbok.ui.theme
+package dev.tuna.leechunbok.resource
 
 import android.app.Activity
 import android.os.Build

--- a/common/resource/src/main/java/dev/tuna/leechunbok/resource/Type.kt
+++ b/common/resource/src/main/java/dev/tuna/leechunbok/resource/Type.kt
@@ -1,4 +1,4 @@
-package dev.tuna.leechunbok.ui.theme
+package dev.tuna.leechunbok.resource
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle


### PR DESCRIPTION
#35 
- App모듈의 Theme파일을 리소스 모듈로 이동하여 모든 모듈에서 참조해서 이용토록 했어요.
- 공통으로 쓸 수 있는 컴포넌트나 파운데이션 파일들은 해당 모듈에 정의해서 쓰도록 해요.